### PR TITLE
Make findAuthorByUsername dynamic

### DIFF
--- a/server.js
+++ b/server.js
@@ -180,7 +180,7 @@ app.get('/api/v1/stories/:id', (request, response) => {
 
 app.post('/api/v1/stories', async (request, response) => {
   const storyInfo = request.body
-  const requiredKeys = ['title', 'story', 'prompt', 'contributors']
+  const requiredKeys = ['title', 'contributions', 'prompt', 'contributors']
 
   if (requiredKeys.every(key => Object.keys(storyInfo).includes(key))) {
     try {


### PR DESCRIPTION
#### What's this PR do?
- fixes login api calls to take a single username key as opposed to a name / email
#### Where should the reviewer start?
server-helpers.js, the primary function that's changed is findAuthorByUsername
#### How should this be manually tested?
Test the `/api/v1/authors/login/` endpoint with a POST request that has only an email and password in its body, formatted like so:
```
{
  "username": "sometestusername@yahoo.com",
  "password": "somepassword"
}
```
this will work provided there's some test users seeded in the database.
#### What are the relevant tickets?
None!
#### Screenshots (if appropriate)
![cat_spin](https://user-images.githubusercontent.com/60753853/93160586-3e7c7700-f6d6-11ea-843e-fb3bfcdfd9f2.gif)